### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

- Created `.editorconfig` at the repo root with all required settings
- Verified `pnpm build` still passes successfully

## Settings Applied

| Setting | Value |
|---|---|
| `indent_style` | `space` |
| `indent_size` | `2` |
| `end_of_line` | `lf` |
| `charset` | `utf-8` |
| `trim_trailing_whitespace` | `true` |
| `insert_final_newline` | `true` |
| `*.md` — `trim_trailing_whitespace` | `false` |

## Definition of Done

- [x] `.editorconfig` file created at repo root
- [x] Settings match the requirements above
- [x] Build still passes (`pnpm build`)

Closes #2